### PR TITLE
fix:use nil rather than empty string for tty

### DIFF
--- a/lib/locksmith/pg.rb
+++ b/lib/locksmith/pg.rb
@@ -36,7 +36,7 @@ module Locksmith
       @conn ||= PG::Connection.open(
         dburl.host,
         dburl.port || 5432,
-        nil, '', #opts, tty
+        nil, nil, #opts, tty
         dburl.path.gsub("/",""), # database name
         dburl.user,
         dburl.password
@@ -53,4 +53,3 @@ module Locksmith
 
   end
 end
-


### PR DESCRIPTION
As of Postgres 14, an empty string is no longer accepted for he tty option. This PR switched to `nil`.

The change is inspired by this PR: https://github.com/QueueClassic/queue_classic/pull/334